### PR TITLE
issue #4

### DIFF
--- a/host_vars/meet.example.com.yml
+++ b/host_vars/meet.example.com.yml
@@ -4,5 +4,5 @@ fqdn_host: meet
 # by default we use letsencrypt and so local_cert is flase
 # set it true to enable local cert usage
 #local_cert: true 
-# also modify certificates src accoriding your local cert location
-#local_certfiles: [{src: '/tmp/fullchain.pem', dst: 'cert.pem'},{src: '/tmp/privkey.pem', dst: 'privkey.pem'}]
+# also modify certificates src according your local cert location
+#local_certfiles: [{src: '/tmp/cert.pem', dst: 'cert.pem'},{src: '/tmp/privkey.pem', dst: 'privkey.pem'}]

--- a/host_vars/meet.example.com.yml
+++ b/host_vars/meet.example.com.yml
@@ -4,5 +4,5 @@ fqdn_host: meet
 # by default we use letsencrypt and so local_cert is flase
 # set it true to enable local cert usage
 #local_cert: true 
-# also modify certifiacates src accoriding your local cert location
-#certfiles: [{src: '/tmp/cert.pem', dst: 'cert.pem'},{src: '/tmp/privkey.pem', dst: 'privkey.pem'}]
+# also modify certificates src accoriding your local cert location
+#local_certfiles: [{src: '/tmp/fullchain.pem', dst: 'cert.pem'},{src: '/tmp/privkey.pem', dst: 'privkey.pem'}]

--- a/roles/mm/tasks/mm.yml
+++ b/roles/mm/tasks/mm.yml
@@ -105,10 +105,10 @@
 - name: Copy local cert
   become: true
   copy:
-    src: "/etc/letsencrypt/live/{{ ansible_fqdn }}/{{ item.src }}"
+    src: "{{ item.src }}"
     dest: "{{ deployment_directory}}/certs/{{ item.dst }}"
     remote_src: true
-  with_items: "{{ certfiles }}"
+  with_items: "{{ local_certfiles }}"
   when: local_cert == true
 
 # Logo


### PR DESCRIPTION
I did another install of the `dev` version (i.e. with new templates) on an intranet host (i.e. with pre-allocated credentials). IMO the following changes are still required, then #4 and #5 are fully resolved:

* `local_certfiles` does not [interfere](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) with `certfiles` in `playbook.yml`
* take entire paths from `local_certfiles`
* `/tmp/fullchain.pem` is a typo: `/tmp/cert.pem` can stay, of course (by way of example)